### PR TITLE
Updating gemspec to work with modern version of httparty

### DIFF
--- a/litmus-instant.gemspec
+++ b/litmus-instant.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "httparty", "~> 0.13.5"
+  spec.add_dependency "httparty", "> 0.13.5", "< 0.16"
 
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/litmus-instant.gemspec
+++ b/litmus-instant.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "httparty", "> 0.13.5", "< 0.16"
+  spec.add_dependency "httparty", ">= 0.13.5", "< 0.16"
 
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
This is required for this gem to work with other gems that use a more modern version of httparty.