### PR TITLE
Reinstate CI as Github Action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: [3.0.x, 2.7.x, 2.6.x, 2.5.x]
+        ruby-version: ['3.0', '2.7', '2.6', '2.5']
 
     steps:
       - uses: actions/checkout@v2
@@ -21,6 +21,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true
       - name: Install dependencies
         run: bundle install
       - name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,6 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
-          bundler-cache: true
-      - name: Install dependencies
-        run: bundle install
+          bundler-cache: true # this includes bundle install
       - name: Run tests
         run: bundle exec rake

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Specs
+name: CI
 
 on:
   push:
@@ -7,7 +7,7 @@ on:
     branches: [ master ]
 
 jobs:
-  test:
+  specs:
 
     runs-on: ubuntu-latest
 
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby ${{ matrix.ruby-version }}
-        uses: ruby/setup-ruby@477b21f02be01bcb8030d50f37cfec92bfa615b6
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
       - name: Install dependencies

--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -1,0 +1,27 @@
+name: Specs
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        ruby-version: [3.0.x, 2.7.x, 2.6.x, 2.5.x]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Ruby ${{ matrix.ruby-version }}
+        uses: ruby/setup-ruby@477b21f02be01bcb8030d50f37cfec92bfa615b6
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+      - name: Install dependencies
+        run: bundle install
+      - name: Run tests
+        run: bundle exec rake


### PR DESCRIPTION
This reinstates CI (that was once long ago using Travis CI's open source plan) using Github Actions and adds a matrix strategy to test across multiple rubies (the latest current 2.5.x, 2.6.x, 2.7.x and 3.0.x releases).